### PR TITLE
Fix raspicat schedule build use image arm64v8-base

### DIFF
--- a/.github/Dockerfile.raspicat-schedule-build
+++ b/.github/Dockerfile.raspicat-schedule-build
@@ -1,4 +1,4 @@
-FROM ubeike/raspicat-noetic:arm64-base
+FROM ubeike/raspicat-noetic:arm64v8-base
 
 SHELL ["/bin/bash", "-c"]
 WORKDIR /root/catkin_ws/


### PR DESCRIPTION
* 使用するイメージ名のタイポを修正